### PR TITLE
Added ability to change SCORM API URL

### DIFF
--- a/lib/scorm_cloud/base.rb
+++ b/lib/scorm_cloud/base.rb
@@ -1,11 +1,12 @@
 module ScormCloud
 	class Base
 
-		attr_reader :appid
+		attr_reader :appid, :api_url
 
-		def initialize(appid, secret)
+		def initialize(appid, secret, api_url = nil)
 			@appid = appid
 			@secret = secret
+      @api_url = api_url ||= 'http://cloud.scorm.com/api'
 		end
 
 		def call(method, params = {})
@@ -57,7 +58,7 @@ module ScormCloud
 					join
 
 			sig = Digest::MD5.hexdigest(raw)
-			"http://cloud.scorm.com/api?#{html_params}&sig=#{sig}"
+			"#{api_url}?#{html_params}&sig=#{sig}"
 		end
 
 

--- a/lib/scorm_cloud/scorm_rails_helpers.rb
+++ b/lib/scorm_cloud/scorm_rails_helpers.rb
@@ -5,7 +5,8 @@ module ScormCloud
   		unless @scorm_cloud
   			@scorm_cloud = ::ScormCloud::ScormCloud.new(
           ::Rails.configuration.scorm_cloud.appid, 
-          ::Rails.configuration.scorm_cloud.secretkey
+          ::Rails.configuration.scorm_cloud.secretkey,
+          ::Rails.configuration.scorm_cloud.api_url
         )
   		end
   		@scorm_cloud

--- a/readme.textile
+++ b/readme.textile
@@ -16,6 +16,17 @@ bc. require 'scorm_cloud'
 sc = ScormCloud::ScormCloud.new("my_app_id","my_secret_key")
 sc.course.get_course_list.each { |c| puts "#{c.id} #{c.title}"}
 
+If you need to change the API URL to utilize the LocalWS engine (for example)
+then pass the API override URL as the third parameter to #initializer
+
+bc. require 'scorm_cloud'
+sc = ScormCloud::ScormCloud.new("my_app_id","my_secret_key","api_override_url")
+sc.course.get_course_list.each { |c| puts "#{c.id} #{c.title}"}
+
+If you do not pass a third parameter then the default will be used
+
+bc. http://cloud.scorm.com/api
+
 h2. Ruby on Rails Use
 
 _Place the following in: Gemfile_
@@ -29,6 +40,10 @@ MyApplication::Application.configure do |config|
 	config.scorm_cloud.appid = "my_app_id"
 	config.scorm_cloud.secretkey = "my_secret_key"
 end
+
+Optionally you can configure the API URL override using
+
+bc. config.scorm_cloud.api_url = "api_override_url"
 
 _Place the following in: /app/controllers.course_controller.rb_
 

--- a/spec/lib/base_test.rb
+++ b/spec/lib/base_test.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe ScormCloud do
+  let (:override_url) { 'http://localhost/api' }
+  let (:default_url) { 'http://cloud.scorm.com/api' }
+  describe "#initialize" do
+    it "should allow api url override" do
+      sc = ScormCloud::ScormCloud.new('app_id','app_secret', override_url)
+      sc.api_url.should eq override_url
+    end
+
+    it "should default to http://cloud.scorm.com/api" do
+      sc = ScormCloud::ScormCloud.new('app_id','app_secret')
+      sc.api_url.should eq default_url
+    end
+  end
+
+  describe "#prepare_url" do
+    it "should contain the api url override" do
+      # have to use launch_url as it returns the resulting call to
+      # prepare_url. The scope of prepare_url is private thus preventing
+      # us from calling it directly
+      sc = ScormCloud::ScormCloud.new('app_id','app_secret', override_url)
+      sc.launch_url('test').include?(override_url).should be_true
+    end
+  end
+end


### PR DESCRIPTION
I added the ability to change the URL of the API used for requests. This allows users of the LocalWS engine to utilize this gem.
