### PR TITLE
Fix variable name for defaulting appid from environment

### DIFF
--- a/lib/scorm_cloud/CLI.rb
+++ b/lib/scorm_cloud/CLI.rb
@@ -2,7 +2,7 @@ module ScormCloud
 	class CLI
 		def self.start
 			command = ARGV.shift
-			secret = ENV['SCORM-CLOUD-APPID']
+			appid = ENV['SCORM-CLOUD-APPID']
 			secret = ENV['SCORM-CLOUD-SECRET']
 			opts = {}
 			while ARGV.length > 0


### PR DESCRIPTION
Fix copy/paste error where the app id was assigned to `secret` instead of `appid`.
